### PR TITLE
Further clarifications and fixes proposed for sycl::stream

### DIFF
--- a/latex/architecture.tex
+++ b/latex/architecture.tex
@@ -636,13 +636,13 @@ scope will be allocated in local memory.
 
 Users can create accessors that reference sub-buffers as well as entire buffers.
 
-Within kernels, accessors can be implicitly cast to C++ pointer types. The
-pointer types will contain a compile-time deduced address space. So, for
-example, if an accessor to global memory is cast to a C++ pointer, the C++
-pointer type will have a global address space attribute attached to it. The
-address space attribute will be compile-time propagated to other pointer
-values when one pointer is initialized to another pointer value using a
-defined mechanism.
+Within kernels, the underlying C++ pointer types can be obtained from an
+accessor. The pointer types will contain a compile-time deduced address space.
+So, for example, if a C++ pointer is obtained from an accessor to global memory, 
+the C++ pointer type will have a global address space attribute attached to it. 
+The address space attribute will be compile-time propagated to other pointer
+values when one pointer is initialized to another pointer value using a defined
+mechanism.
 
 When developers need to explicitly state the address space of a pointer value,
 one of the explicit pointer classes can be used. There is a different explicit

--- a/latex/compiler_abi.tex
+++ b/latex/compiler_abi.tex
@@ -339,7 +339,7 @@ Table~\ref{table.types.fundamental}.
   A 16-bit floating-point. The half data type must conform to the IEEE 754-2008
   half precision storage format. A SYCL \codeinline{feature_not_supported}
   exception must be thrown if the \codeinline{half} type is used in a SYCL
-  kernel fucntion which executes on a SYCL \codeinline{device} that does not
+  kernel function which executes on a SYCL \codeinline{device} that does not
   support the extension \codeinline{khr_fp16}.
 }
 \completeTable

--- a/latex/device_class.tex
+++ b/latex/device_class.tex
@@ -139,7 +139,7 @@ A synopsis of the SYCL \codeinline{device} class is provided below. The construc
    {  info::device_type deviceType = }
    {  info::device_type::all)}
    {
-     Returns a \codeinline{vector_class} containing all SYCL \codeinline{device}s available in the system of the device type specified by the parameter \codeinline{deviceType}. The returned \codeinline{vector_class} must contain a single SYCL \codeinline{device} that is a host device, permitted by the \codeinline{deviceType} parameter.
+     Returns a \codeinline{vector_class} containing all SYCL \codeinline{device}s available in the system of the device type specified by the parameter \codeinline{deviceType}. The returned \codeinline{vector_class} must contain at least a SYCL \codeinline{device} that is a host device if the \codeinline{deviceType} is \codeinline{info::device_type::all}, or a single host device if the \codeinline{deviceType} is \codeinline{info::device_type::host}.
    }
 \completeTable
 %-------------------------------------------------------------------------------

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -33,7 +33,7 @@ written in row-major format.
   \addRow {item} {Pairing of an \codeinline{id} (specific point) and the \codeinline{range} that it is bounded by}
   \addRow {nd_range} {Encapsules both global and local (work-group size) \mbox{\codeinline{range}s} over which work-item \mbox{\codeinline{id}s} will vary}
   \addRow {nd_item} {Encapsulates two \mbox{\codeinline{item}s}, one for global \codeinline{id} and \codeinline{range}, and one for local \codeinline{id} and \codeinline{range}}
-  \addRow {h_item} {Index point queries within hierarchical parallelism (\codeinline{parallel_for_work_item}).  Encapsulates physical global and local \mbox{\codeinline{id}s} and \mbox{\codeinline{range}s}, as well as a logical/flexible local \codeinline{id} and \codeinline{range} defined by hierarchical parallelism}
+  \addRow {h_item} {Index point queries within hierarchical parallelism (\codeinline{parallel_for_work_item}).  Encapsulates physical global and local \mbox{\codeinline{id}s} and \mbox{\codeinline{range}s}, as well as a logical local \codeinline{id} and \codeinline{range} defined by hierarchical parallelism}
   \addRow {group} {Work-group queries within hierarchical parallelism (\codeinline{parallel_for_work_group}), and exposes the \codeinline{parallel_for_work_item} construct that identifies code to be executed by each work-item.  Encapsulates work-group \mbox{\codeinline{id}s} and \mbox{\codeinline{range}s}}
 \completeTable
 %-------------------------------------------------------------------------------
@@ -777,7 +777,7 @@ call or to the corresponding \codeinline{parallel_for_work_group} call if no \co
 is passed to the \codeinline{parallel_for_work_item} call.
 It encapsulates enough information to identify the \gls{work-item}'s local and global \glspl{item}
 according to the information given to \codeinline{parallel_for_work_group} (physical ids)
-as well as the \gls{work-item}'s logical local \glspl{item} in the flexible range.
+as well as the \gls{work-item}'s logical local \glspl{item} in the logical local range.
 All returned \glspl{item} objects are offset-less.
 Instances of the \codeinline{h_item<int dimensions>} class are not
 user-constructible and are passed by the runtime to each instance of the
@@ -812,7 +812,7 @@ A synopsis of the SYCL \codeinline{h_item} class is provided below. The member f
         work-item's position in the local iteration space as provided upon the invocation of the
         \codeinline{group::parallel_for_work_item}.
 
-        If the \codeinline{group::parallel_for_work_item} was called without any flexible local range
+        If the \codeinline{group::parallel_for_work_item} was called without any logical local range
         then the member function returns the physical local \gls{item}.
 
         A physical id can be computed from a logical id by getting the reminder of the integer division
@@ -1026,24 +1026,24 @@ operation.
   \addRowThreeL
     {template <typename workItemFunctionT>}
     {void parallel_for_work_item(range<dimensions> }
-    { flexibleRange, workItemFunctionT func) const}
+    { logicalRange, workItemFunctionT func) const}
     {
       Launch the work-items for this work-group using a logical local range.
       The function object \codeinline{func} is executed as if the kernel where
-      invoked with \codeinline{flexibleRange} as the local range. This new local
+      invoked with \codeinline{logicalRange} as the local range. This new local
       range is emulated and may not map one-to-one with the physical range.
       
-      \codeinline{flexibleRange} is the new local range to be used.
+      \codeinline{logicalRange} is the new local range to be used.
       This range can be smaller or larger than the one used to invoke the kernel.
       \codeinline{func} is a function object type with a public member function
       \codeinline{void F::operator()(h_item<dimensions>)}
       representing the work-item computation.
 
-      Note that the flexible range does not need to be uniform
-      across all work-groups in a kernel.  For example the flexible range may depend on
+      Note that the logical range does not need to be uniform
+      across all work-groups in a kernel.  For example the logical range may depend on
       a work-group varying query (e.g. \codeinline{group::get_linear_id}),
       such that different work-groups in the same kernel invocation execute
-      different flexible range sizes.
+      different logical range sizes.
 
       This member function can only be invoked within a
       \codeinline{parallel_for_work_group} context.

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -815,7 +815,7 @@ A synopsis of the SYCL \codeinline{h_item} class is provided below. The member f
         If the \codeinline{group::parallel_for_work_item} was called without any logical local range
         then the member function returns the physical local \gls{item}.
 
-        A physical id can be computed from a logical id by getting the reminder of the integer division
+        A physical id can be computed from a logical id by getting the remainder of the integer division
         of the logical id and the physical range:
         \codeinline{get_logical_local().get() \% get_physical_local.get_range() == get_physical_local().get()}.
     }

--- a/latex/expressingParallelism.tex
+++ b/latex/expressingParallelism.tex
@@ -972,6 +972,7 @@ operation.
     {range<dimensions> get_local_range() const}
     {
         Return a SYCL \codeinline{range} representing all dimensions of the local range.
+        This local range may have been provided by the programmer, or chosen by the \gls{sycl-runtime}.
     }
   \addRow
     {size_t get_local_range(int dimension) const}
@@ -981,9 +982,7 @@ operation.
   \addRow
     {range<dimensions> get_group_range() const}
     {
-        Return a \codeinline{range} representing the dimensions of the
-        current group.  This local range may have been provided by the
-        programmer, or chosen by the \gls{sycl-runtime}.
+        Return a \codeinline{range} representing the number of \glspl{work-group} in the \codeinline{nd_range}.
     }
   \addRow
     {size_t get_group_range(int dimension) const}

--- a/latex/headers/group.h
+++ b/latex/headers/group.h
@@ -30,7 +30,7 @@ public:
   void parallel_for_work_item(workItemFunctionT func) const;
 
   template<typename workItemFunctionT>
-  void parallel_for_work_item(range<dimensions> flexibleRange,
+  void parallel_for_work_item(range<dimensions> logicalRange,
     workItemFunctionT func) const;
 
   template <access::mode accessMode = access::mode::read_write>

--- a/latex/headers/stream.h
+++ b/latex/headers/stream.h
@@ -2,6 +2,7 @@ namespace cl {
 namespace sycl {
 
 enum class stream_manipulator {
+  flush,
   dec,
   hex,
   oct,
@@ -15,6 +16,9 @@ enum class stream_manipulator {
   hexfloat,
   defaultfloat
 };
+
+
+const stream_manipulator flush = stream_manipulator::flush;
 
 const stream_manipulator dec = stream_manipulator::dec;
 
@@ -47,12 +51,16 @@ __width_manipulator__ setw(int width);
 class stream {
  public:
 
-  stream(size_t bufferSize, size_t maxStatementSize, handler& cgh);
+  stream(size_t totalBufferSize, size_t workItemBufferSize, handler& cgh);
 
   /* -- common interface members -- */
 
   size_t get_size() const;
 
+  size_t get_work_item_buffer_size() const;
+
+  /* get_max_statement_size() is an alias for get_work_item_buffer_size(), and
+     is provided for backward compatibility */
   size_t get_max_statement_size() const;
 };
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -3183,7 +3183,7 @@ These aliases are described in Table~\ref{table.types.aliases}
   Alias to a 16-bit floating-point. The half data type must conform to the IEEE
   754-2008 half precision storage format. A SYCL \codeinline{feature_not_supported}
   exception must be thrown if the \codeinline{half} type is used in a SYCL kernel
-  fucntion which executes on a SYCL \codeinline{device} that does not support the
+  function which executes on a SYCL \codeinline{device} that does not support the
   extension \codeinline{khr_fp16}.
 }
 \completeTable

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -90,7 +90,7 @@ For more details regarding these facilities and considerations for their use see
 \subsection{Common reference semantics}
 \label{sec:reference-semantics}
 
-Each of the following \gls{sycl-runtime} classes: \codeinline{device}, \codeinline{context}, \codeinline{queue}, \codeinline{program}, \codeinline{kernel}, \codeinline{event}, \codeinline{buffer}, \codeinline{image}, \codeinline{sampler}, \codeinline{accessor} and \codeinline{stream} must obey the following statements, where \codeinline{T} is the runtime class type:
+Each of the following \gls{sycl-runtime} classes: \codeinline{device}, \codeinline{context}, \codeinline{queue}, \codeinline{program}, \codeinline{kernel}, \codeinline{event}, \codeinline{buffer}, \codeinline{image}, \codeinline{sampler} and \codeinline{accessor} must obey the following statements, where \codeinline{T} is the runtime class type:
 
 \begin{itemize}
 

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -1260,7 +1260,7 @@ The SYCL \codeinline{buffer} class template takes a template parameter \codeinli
       exceed the parent buffer (\codeinline{b}) size (\codeinline{bufferRange}) in that dimension,
       and an \codeinline{invalid_object_error} SYCL exception must be thrown if violated.
       The offset and range specified by \codeinline{baseIndex} and \codeinline{subRange} together must represent a contiguous region of the original SYCL \codeinline{buffer}.  This contiguous region restriction avoids runtime overhead on top of one-dimensional sub-buffers exposed by OpenCL.  If a non-contiguous region of a buffer is requested when constructing a sub-buffer, then an \codeinline{invalid_object_error} SYCL exception must be thrown.
-      The total size of the sub-buffer being constructed must be a multiple of the memory base address alignment of each SYCL \codeinline{device} that is executed on, otherwise the \gls{sycl-runtime} must throw an asynchronous \codeinline{invalid_object_error} SYCL exception.
+      The origin (based on \codeinline{baseIndex}) of the sub-buffer being constructed must be a multiple of the memory base address alignment of each SYCL \codeinline{device} that is executed on, otherwise the \gls{sycl-runtime} must throw an asynchronous \codeinline{invalid_object_error} SYCL exception.
       This value is retrievable via the SYCL \codeinline{device} class info query \codeinline{info::device::mem_base_addr_align}.
       Must throw an \codeinline{invalid_object_error} SYCL exception if \codeinline{b} is already a sub-buffer.
     }

--- a/latex/programming_interface.tex
+++ b/latex/programming_interface.tex
@@ -69,7 +69,7 @@ defaulted as 1 in most cases.
 Many of the \gls{sycl-runtime} classes encapsulate an associated OpenCL opaque type and provide facilities for interoperating between the SYCL classes and the OpenCL opaque types they encapsulate in order to allow interoperability between SYCL and OpenCL applications.
 
 Each of the following \gls{sycl-runtime} classes: \codeinline{platform},
-\codeinline{device}, \codeinline{context}, \codeinline{queue}, \codeinline{program}, \codeinline{kernel}, \codeinline{event}, \codeinline{buffer}, \codeinline{image}, \codeinline{sampler} and \codeinline{stream} must obey the following statements, where \codeinline{T} is the runtime class type:
+\codeinline{device}, \codeinline{context}, \codeinline{queue}, \codeinline{program}, \codeinline{kernel}, \codeinline{event}, \codeinline{buffer}, \codeinline{image} and \codeinline{sampler} must obey the following statements, where \codeinline{T} is the runtime class type:
 
 \begin{itemize}
 
@@ -3559,13 +3559,13 @@ work-item to make progress if the code is to be portable.
 \section{Stream class}
 \label{subsection:stream}
 
-The SYCL \codeinline{stream} class is a buffered output stream that allows outputting the values of built-in, vector and SYCL types to the console. The implementation of how values are streamed is left as an implementation detail.
+The SYCL \codeinline{stream} class is a buffered output stream that allows outputting the values of built-in, vector and SYCL types to the console. The implementation of how values are streamed to the console is left as an implementation detail.
 
 The way in which values are output by an instance of the SYCL \codeinline{stream} class can also be altered using a range of manipulators.
 
-An instance of the SYCL \codeinline{stream} class has a maximum buffer size (\codeinline{bufferSize}) that specifies maximum size of the character stream that can be output by any single work item in characters (a character is of size \codeinline{sizeof(char)} bytes) during a kernel invocation, and a maximum statement size (\codeinline{maxStatementSize}) that specifies the maximum size of the character stream that can be output in a single statement in characters (a character is of size \codeinline{sizeof(char)} bytes).  \codeinline{bufferSize} must be sufficient to contain the characters output by statements during execution of a work item, and \codeinline{maxStatementSize} must be sufficient to contain the characters output by any specific statement, otherwise behavior is undefined.  Unused characters within \codeinline{maxStatementSize} (any portion of the \codeinline{maxStatementSize} that is not used/output by a statement) do not count toward the \codeinline{bufferSize} limit of a work item.
+An instance of the SYCL \codeinline{stream} class has a maximum buffer size (\codeinline{totalBufferSize}) that specifies maximum size of the overall character stream that can be output in characters (a character is of size \codeinline{sizeof(char)} bytes) during a kernel invocation, and a maximum stream size (\codeinline{workItemBufferSize}) that specifies the maximum size of the character stream (number of characters) that can be output within a work item before a flush must be performed (a character is of size \codeinline{sizeof(char)} bytes).  \codeinline{totalBufferSize} must be sufficient to contain the characters output by all stream statements during execution of a kernel invocation (the aggregate of outputs from all work items), and \codeinline{workItemBufferSize} must be sufficient to contain the characters output within a work item between stream flush operations.
 
-All member functions of the \codeinline{stream} class are synchronous and errors are handled by throwing synchronous SYCL exceptions.
+If the \codeinline{totalBufferSize} or \codeinline{workItemBufferSize} limits are exceeded, it is implementation defined whether the streamed characters exceeding the limit are output, or silently ignored/discarded, and if output it is implementation defined whether those extra characters exceeding the \codeinline{workItemBufferSize} limit count toward the \codeinline{totalBufferSize} limit.  Regardless of this implementations defined behavior of output exceeding the limits, no undefined or erroneous behavior is permitted of an implementation when the limits are exceeded.  Unused characters within \codeinline{workItemBufferSize} (any portion of the \codeinline{workItemBufferSize} capacity that has not been used at the time of a stream flush) do not count toward the \codeinline{totalBufferSize} limit, in that only characters flushed count toward the \codeinline{totalBufferSize} limit.
 
 The SYCL \codeinline{stream} class provides the common reference semantics
 (see Section~\ref{sec:reference-semantics}).
@@ -3637,10 +3637,19 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
 \addFootNotes{Manipulators supported by the \codeinline{stream} class}{table.manipulators.stream}
 \addRow
 {
+  flush
+}
+{
+  Triggers a flush operation, that synchronizes the work item stream buffer with the global
+  stream buffer, and that empties the work item stream buffer.  After a flush, the full
+  \codeinline{workItemBufferSize} is available again for subsequent streaming within the work item.
+}
+\addRow
+{
   endl
 }
 {
-  Outputs a new-line character.
+  Outputs a new-line character and then generates a flush.
 }
 \addRow
 {
@@ -3740,9 +3749,9 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
 \startTable{Constructor}
     \addFootNotes{Constructors of the \codeinline{stream} class}{table.constructors.stream}
   \addRow
-    {stream(size_t bufferSize, size_t maxStatementSize, handler\& cgh)}
+    {stream(size_t totalBufferSize, size_t workItemBufferSize, handler\& cgh)}
     {
-      Constructs a SYCL \codeinline{stream} instance associated with the command group specified by \codeinline{cgh}, with a maximum buffer size per work item specified by the parameter \codeinline{bufferSize} and a maximum statement size specified by the parameter \codeinline{maxStatementSize}.  \codeinline{bufferSize} and \codeinline{maxStatementSize} relate to memory storage size in that they are the term \codeinline{n} in \codeinline{alloc_size = n*sizeof(char)}.
+      Constructs a SYCL \codeinline{stream} instance associated with the command group specified by \codeinline{cgh}, with a maximum buffer size in characters per kernel invocation specified by the parameter \codeinline{totalBufferSize}, and a maximum stream size that can be buffered by a work item between stream flushes specified by the parameter \codeinline{workItemBufferSize}.  \codeinline{totalBufferSize} and \codeinline{workItemBufferSize} relate to memory storage size in that they are the term \codeinline{n} in \codeinline{alloc_size = n*sizeof(char)}.
     }
 \completeTable
 %-------------------------------------------------------------------------------
@@ -3753,12 +3762,12 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
   \addRow
     {size_t get_size() const}
     {
-      Returns the maximum buffer size.
+      Returns the total buffer size, in characters.
     }
   \addRow
-    {size_t get_max_statement_size() const}
+    {size_t get_work_item_buffer_size() const}
     {
-      Returns the maximum statement size.
+      Returns the buffer size per work item, in characters.
     }
 \completeTable
 %-------------------------------------------------------------------------------------------
@@ -3770,16 +3779,19 @@ The manipulators that are supported by the SYCL \codeinline{stream} class \codei
   \addRow
     {template <typename T> const stream\& operator<<(const stream\& os, const T \&rhs)}
     {
-      Outputs any valid values (see~\ref{table.operands.stream}) as a stream of characters and applies any valid manipulator (see~\ref{table.manipulators.stream}) to the current statements.
+      Outputs any valid values (see~\ref{table.operands.stream}) as a stream of characters and applies any valid manipulator (see~\ref{table.manipulators.stream}) to the current stream.
     }
 \completeTable
 %-------------------------------------------------------------------------------------------
 
 \subsection{Synchronization}
 
-An instance of the SYCL \codeinline{stream} class is required to synchronize with the host, and must output everything that is streamed to it via the \codeinline{operator<<()} operator (that doesn't exceed the \codeinline{maxStatementSize} or \codeinline{bufferSize} limits) within a SYCL kernel function by the time that the event associated with a command group submission enters the completed state. The point at which this synchronization occurs and the method by which this synchronization is performed are implementation defined. For example it is valid for an implementation to use \codeinline{printf()}.
+An instance of the SYCL \codeinline{stream} class is required to synchronize with the host, and must output everything that is streamed to it via the \codeinline{operator<<()} operator (that doesn't exceed the \codeinline{workItemBufferSize} or \codeinline{totalBufferSize} limits) within a SYCL kernel function by the time that the event associated with a command group submission enters the completed state. The point at which this synchronization occurs and the method by which this synchronization is performed are implementation defined. For example it is valid for an implementation to use \codeinline{printf()}.
 
-The SYCL \codeinline{stream} class is required to output each statement (up to \codeinline{maxStatementSize}) without mixing with statements of other work items.  There are no other output order guarantees between work items.  It is undefined behavor if a statement exceeds \codeinline{maxStatementSize}, or if the sum of outputs from all statements within execution of a work item exceed \codeinline{bufferSize}.
+The SYCL \codeinline{stream} class is required to output the content of each stream, between flushes (up to \codeinline{workItemBufferSize}), without mixing with content from the same stream in other work items.  There are no other output order guarantees between work items or between streams.  The stream flush operation therefore delimits the unit of output that is guaranteed to be displayed without mixing with other work items, with respect to a single stream.
+
+\subsection{Implicit flush}
+There is guaranteed to be an implicit flush of each stream used by a kernel, at the end of kernel execution, from the perspective of each work item.  There is also an implicit flush when the endl stream manipulator is executed.  No other implicit flushes are permitted in an implementation. 
 
 \subsection{Performance note}
 

--- a/latex/queue_class.tex
+++ b/latex/queue_class.tex
@@ -192,14 +192,14 @@ Tables~\ref{table.specialmembers.common.reference} and
   \addRow
     {void wait() }
     {
-      Performs a blocking wait for the completion all enqueued tasks
+      Performs a blocking wait for the completion of all enqueued tasks
       in the queue.  Synchronous errors will be reported through SYCL
       exceptions.
     }
   \addRow
     {void wait_and_throw () }
     {
-      Performs a blocking wait for the completion all enqueued tasks
+      Performs a blocking wait for the completion of all enqueued tasks
       in the queue.  Synchronous errors will be reported via SYCL
       exceptions. Asynchronous errors will be passed to the
       \gls{async-handler} passed to the queue on


### PR DESCRIPTION
Since we're clarifying and applying fixes for the stream class anyway also align it with C++ iostream semantics